### PR TITLE
Fix failing import from "markupsafe"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL "homepage"="https://github.com/grantmcconnaughey/lintly-flake8-github-acti
 LABEL "maintainer"="Grant McConnaughey <grantmcconnaughey@gmail.com>"
 
 RUN pip install --upgrade pip
+RUN pip install markupsafe==2.0.1
 RUN pip install flake8
 RUN pip install lintly
 


### PR DESCRIPTION
Use [@ikerexe](https://github.com/ikerexxe)'s fix for the lintly dependency inconsistencies.

Force version 2.0.1 from "markupsafe" to avoid the error.

Signed-off-by: Iker Pedrosa <ipedrosa@redhat.com>